### PR TITLE
Implement optional features 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ dkms.conf
 *.dwo
 
 /build
+/tmp
+http_server
+http_client
+/build-rel

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,23 @@
 #   make release    # Release 構成でビルド & テスト
 #   make clean      # 生成物削除
 #   make test-debug / make test-release も可
+#   make http_server  # HTTPサーバーをビルド
+#   make http_client  # HTTPクライアントをビルド
 
 CMAKE  ?= cmake
 CTEST  ?= ctest
+CC     ?= cc
+CFLAGS  = -Wall -Werror -O2
 
 BUILD_DEBUG    := build
 BUILD_RELEASE  := build-rel
 CONFIG_DEBUG   := Debug
 CONFIG_RELEASE := Release
-
-.PHONY: all debug release test-debug test-release clean
+HTTP_SERVER_SRCS      := app/http_server_main.c src/http_request.c src/http_request_io.c src/http_response.c src/http_calc.c src/calc.c src/socket_io.c
+HTTP_SERVER_TARGET    := http_server
+HTTP_CLIENT_SRCS      := app/http_client_main.c src/http_client.c src/socket_io.c
+HTTP_CLIENT_TARGET    := http_client
+.PHONY: all debug release test-debug test-release clean http_server http_client
 
 all: debug
 
@@ -39,4 +46,11 @@ test-release: release
 
 # --- Clean ---
 clean:
-	rm -rf $(BUILD_DEBUG) $(BUILD_RELEASE)
+	rm -rf $(BUILD_DEBUG) $(BUILD_RELEASE) $(HTTP_SERVER_TARGET) $(HTTP_CLIENT_TARGET)
+
+# --- HTTP Server ---
+http_server: $(HTTP_SERVER_SRCS)
+	$(CC) $(CFLAGS) -o $(HTTP_SERVER_TARGET) $(HTTP_SERVER_SRCS)
+
+http_client: $(HTTP_CLIENT_SRCS)
+	$(CC) $(CFLAGS) -o $(HTTP_CLIENT_TARGET) $(HTTP_CLIENT_SRCS)

--- a/app/http_client_main.c
+++ b/app/http_client_main.c
@@ -26,6 +26,7 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "open_client_fd: %s\n", strerror(err));
     return EXIT_FAILURE;
   }
+  set_socket_timeout(fd, 30);
 
   char *request = NULL;
   size_t request_length = 0;

--- a/app/http_client_main.c
+++ b/app/http_client_main.c
@@ -1,0 +1,65 @@
+#include "../src/http_client.h"
+#include "../src/socket_io.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define HOST "localhost"
+#define PORT "80"
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        fprintf(stderr,
+            "usage: %s \"<request-line>\"\n"
+            "example: %s \"GET /calc?query=2+10 HTTP/1.1\"\n",
+            argv[0], argv[0]);
+        return EXIT_FAILURE;
+    }
+    const char *request_line = argv[1];
+
+    const int fd = open_client_fd(HOST, PORT);
+    if (fd == -1) {
+        const int err = errno;
+        fprintf(stderr, "open_client_fd: %s\n", strerror(err));
+        return EXIT_FAILURE;
+    }
+
+    char *request = NULL;
+    size_t request_length = 0;
+    if (build_request_dup(&request, &request_length,
+                          request_line) < 0) {
+        const int err = errno;
+        fprintf(stderr, "build_request_dup: %s\n", strerror(err));
+        close(fd);
+        return EXIT_FAILURE;
+    }
+
+    if (write_all(fd, request, request_length) < 0) {
+        const int err = errno;
+        fprintf(stderr, "write_all: %s\n", strerror(err));
+        free(request);
+        close(fd);
+        return EXIT_FAILURE;
+    }
+    free(request);
+
+    shutdown(fd, SHUT_WR);
+
+    char *response = NULL;
+    const ssize_t bytes_read = read_all(fd, &response);
+    if (bytes_read < 0) {
+        const int err = errno;
+        fprintf(stderr, "read_all: %s\n", strerror(err));
+        close(fd);
+        return EXIT_FAILURE;
+    }
+
+    fwrite(response, 1, (size_t)bytes_read, stdout);
+    free(response);
+
+    close(fd);
+    return EXIT_SUCCESS;
+}

--- a/app/http_client_main.c
+++ b/app/http_client_main.c
@@ -11,55 +11,54 @@
 #define PORT "80"
 
 int main(int argc, char *argv[]) {
-    if (argc != 2) {
-        fprintf(stderr,
+  if (argc != 2) {
+    fprintf(stderr,
             "usage: %s \"<request-line>\"\n"
             "example: %s \"GET /calc?query=2+10 HTTP/1.1\"\n",
             argv[0], argv[0]);
-        return EXIT_FAILURE;
-    }
-    const char *request_line = argv[1];
+    return EXIT_FAILURE;
+  }
+  const char *request_line = argv[1];
 
-    const int fd = open_client_fd(HOST, PORT);
-    if (fd == -1) {
-        const int err = errno;
-        fprintf(stderr, "open_client_fd: %s\n", strerror(err));
-        return EXIT_FAILURE;
-    }
+  const int fd = open_client_fd(HOST, PORT);
+  if (fd == -1) {
+    const int err = errno;
+    fprintf(stderr, "open_client_fd: %s\n", strerror(err));
+    return EXIT_FAILURE;
+  }
 
-    char *request = NULL;
-    size_t request_length = 0;
-    if (build_request_dup(&request, &request_length,
-                          request_line) < 0) {
-        const int err = errno;
-        fprintf(stderr, "build_request_dup: %s\n", strerror(err));
-        close(fd);
-        return EXIT_FAILURE;
-    }
-
-    if (write_all(fd, request, request_length) < 0) {
-        const int err = errno;
-        fprintf(stderr, "write_all: %s\n", strerror(err));
-        free(request);
-        close(fd);
-        return EXIT_FAILURE;
-    }
-    free(request);
-
-    shutdown(fd, SHUT_WR);
-
-    char *response = NULL;
-    const ssize_t bytes_read = read_all(fd, &response);
-    if (bytes_read < 0) {
-        const int err = errno;
-        fprintf(stderr, "read_all: %s\n", strerror(err));
-        close(fd);
-        return EXIT_FAILURE;
-    }
-
-    fwrite(response, 1, (size_t)bytes_read, stdout);
-    free(response);
-
+  char *request = NULL;
+  size_t request_length = 0;
+  if (build_request_dup(&request, &request_length, request_line) < 0) {
+    const int err = errno;
+    fprintf(stderr, "build_request_dup: %s\n", strerror(err));
     close(fd);
-    return EXIT_SUCCESS;
+    return EXIT_FAILURE;
+  }
+
+  if (write_all(fd, request, request_length) < 0) {
+    const int err = errno;
+    fprintf(stderr, "write_all: %s\n", strerror(err));
+    free(request);
+    close(fd);
+    return EXIT_FAILURE;
+  }
+  free(request);
+
+  shutdown(fd, SHUT_WR);
+
+  char *response = NULL;
+  const ssize_t bytes_read = read_all(fd, &response);
+  if (bytes_read < 0) {
+    const int err = errno;
+    fprintf(stderr, "read_all: %s\n", strerror(err));
+    close(fd);
+    return EXIT_FAILURE;
+  }
+
+  fwrite(response, 1, (size_t)bytes_read, stdout);
+  free(response);
+
+  close(fd);
+  return EXIT_SUCCESS;
 }

--- a/app/http_server_main.c
+++ b/app/http_server_main.c
@@ -1,0 +1,97 @@
+#include "../src/http_calc.h"
+#include "../src/http_request.h"
+#include "../src/http_request_io.h"
+#include "../src/http_response.h"
+#include "../src/socket_io.h"
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define PORT 80
+#define BACKLOG 128
+
+static void handle_connection(int client_fd) {
+  char *request_line_string = NULL;
+  char *calculation_result = NULL;
+  char *response = NULL;
+  RequestLine request_line = {0};
+
+  if (read_request_line(client_fd, &request_line_string) != 0)
+    goto cleanup;
+  if (parse_request_line_dup(request_line_string, &request_line) != 0)
+    goto cleanup;
+  if (calc_eval_request_line_dup(&request_line, &calculation_result) != 0)
+    goto cleanup;
+  if (build_resp_dup(&response, calculation_result) != 0)
+    goto cleanup;
+
+  if (send_all(client_fd, response, strlen(response)) != 0) {
+    int error = errno;
+    if (error == EPIPE || error == ECONNRESET) {
+      fprintf(stderr, "Connection closed by peer\n");
+    } else {
+      fprintf(stderr, "Connection system error: %s\n", strerror(error));
+    }
+  }
+
+cleanup:
+  request_line_cleanup(&request_line);
+  free(response);
+  free(calculation_result);
+  free(request_line_string);
+  close(client_fd);
+}
+
+int main(void) {
+  const int server_socket = socket(AF_INET, SOCK_STREAM, 0);
+  if (server_socket == -1) {
+    fprintf(stderr, "[socket] errno=%d (%s)\n", errno, strerror(errno));
+    return EXIT_FAILURE;
+  }
+
+  const int enable_reuse = 1;
+  if (setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR, &enable_reuse,
+                 sizeof(enable_reuse)) == -1) {
+    fprintf(stderr, "[setsockopt] errno=%d (%s)\n", errno, strerror(errno));
+    close(server_socket);
+    return EXIT_FAILURE;
+  }
+
+  struct sockaddr_in server_address = {0};
+  server_address.sin_family = AF_INET;
+  server_address.sin_port = htons(PORT);
+  server_address.sin_addr.s_addr = htonl(INADDR_ANY);
+
+  if (bind(server_socket, (struct sockaddr *)&server_address,
+           sizeof(server_address)) == -1) {
+    fprintf(stderr, "[bind] errno=%d (%s)\n", errno, strerror(errno));
+    close(server_socket);
+    return EXIT_FAILURE;
+  }
+  if (listen(server_socket, BACKLOG) == -1) {
+    fprintf(stderr, "[listen] errno=%d (%s)\n", errno, strerror(errno));
+    close(server_socket);
+    return EXIT_FAILURE;
+  }
+
+  for (;;) {
+    const int client_fd = accept(server_socket, NULL, NULL);
+    if (client_fd == -1) {
+      const int error = errno;
+      if (error == EINTR || error == ECONNABORTED)
+        continue;
+      if (error == EMFILE || error == ENFILE || error == ENOMEM) {
+        usleep(10000);
+        continue;
+      }
+      fprintf(stderr, "[accept] errno=%d (%s)\n", error, strerror(error));
+      continue;
+    }
+    handle_connection(client_fd);
+  }
+}

--- a/app/http_server_main.c
+++ b/app/http_server_main.c
@@ -54,7 +54,6 @@ cleanup:
   close(client_fd);
 }
 
-
 int main(void) {
   struct sigaction sa = {0};
   sa.sa_handler = handler;
@@ -105,6 +104,7 @@ int main(void) {
 
   for (;;) {
     const int client_fd = accept(server_socket, NULL, NULL);
+
     if (client_fd == -1) {
       const int error = errno;
       if (error == EINTR) {
@@ -119,6 +119,10 @@ int main(void) {
       }
       fprintf(stderr, "[accept] errno=%d (%s)\n", error, strerror(error));
       continue;
+    }
+    if(set_socket_timeout(client_fd, 5) == -1) {
+      fprintf(stderr, "[setsockopt SO_RCVTIMEO/SO_SNDTIMEO] errno=%d (%s)\n",
+              errno, strerror(errno));
     }
     handle_connection(client_fd);
 

--- a/app/http_server_main.c
+++ b/app/http_server_main.c
@@ -4,6 +4,7 @@
 #include "../src/http_response.h"
 #include "../src/socket_io.h"
 #include <errno.h>
+#include <signal.h>
 #include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,6 +15,12 @@
 
 #define PORT 80
 #define BACKLOG 128
+
+static volatile sig_atomic_t stop_flag = 0;
+
+void handler(int sig) {
+  stop_flag = 1;
+}
 
 static void handle_connection(int client_fd) {
   char *request_line_string = NULL;
@@ -47,7 +54,15 @@ cleanup:
   close(client_fd);
 }
 
+
 int main(void) {
+  struct sigaction sa = {0};
+  sa.sa_handler = handler;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sigaction(SIGINT, &sa, NULL);
+  sigaction(SIGTERM, &sa, NULL);
+
   const int server_socket = socket(AF_INET6, SOCK_STREAM, 0);
   if (server_socket == -1) {
     fprintf(stderr, "[socket] errno=%d (%s)\n", errno, strerror(errno));
@@ -92,7 +107,11 @@ int main(void) {
     const int client_fd = accept(server_socket, NULL, NULL);
     if (client_fd == -1) {
       const int error = errno;
-      if (error == EINTR || error == ECONNABORTED)
+      if (error == EINTR) {
+        if (stop_flag) break;
+        continue;
+      }
+      if (error == ECONNABORTED)
         continue;
       if (error == EMFILE || error == ENFILE || error == ENOMEM) {
         usleep(10000);
@@ -102,5 +121,10 @@ int main(void) {
       continue;
     }
     handle_connection(client_fd);
+
+    if (stop_flag) {
+      break;
+    }
   }
+  close(server_socket);
 }

--- a/app/http_server_main.c
+++ b/app/http_server_main.c
@@ -48,7 +48,7 @@ cleanup:
 }
 
 int main(void) {
-  const int server_socket = socket(AF_INET, SOCK_STREAM, 0);
+  const int server_socket = socket(AF_INET6, SOCK_STREAM, 0);
   if (server_socket == -1) {
     fprintf(stderr, "[socket] errno=%d (%s)\n", errno, strerror(errno));
     return EXIT_FAILURE;
@@ -62,10 +62,19 @@ int main(void) {
     return EXIT_FAILURE;
   }
 
-  struct sockaddr_in server_address = {0};
-  server_address.sin_family = AF_INET;
-  server_address.sin_port = htons(PORT);
-  server_address.sin_addr.s_addr = htonl(INADDR_ANY);
+  const int ipv6only = 0;
+  if (setsockopt(server_socket, IPPROTO_IPV6, IPV6_V6ONLY,
+               &ipv6only, sizeof(ipv6only)) == -1) {
+    fprintf(stderr, "[setsockopt IPV6_V6ONLY] errno=%d (%s)\n",
+            errno, strerror(errno));
+    close(server_socket);
+    return EXIT_FAILURE;
+  }
+
+  struct sockaddr_in6 server_address = {0};
+  server_address.sin6_family = AF_INET6;
+  server_address.sin6_port = htons(PORT);
+  server_address.sin6_addr = in6addr_any;
 
   if (bind(server_socket, (struct sockaddr *)&server_address,
            sizeof(server_address)) == -1) {

--- a/src/calc.c
+++ b/src/calc.c
@@ -1,0 +1,79 @@
+#include "calc.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+int eval_sum(const char *expression, int *out) {
+  if (!expression || !out) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  char *plus_sign = strchr(expression, '+');
+  if (!plus_sign) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  errno = 0;
+  char *left_end_ptr = NULL;
+  const long left_operand = strtol(expression, &left_end_ptr, 10);
+  if (left_end_ptr != plus_sign) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (errno == ERANGE)
+    return -1;
+
+  errno = 0;
+  char *right_end_ptr = NULL;
+  const long right_operand = strtol(plus_sign + 1, &right_end_ptr, 10);
+  if (right_end_ptr == plus_sign + 1) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (*right_end_ptr != '\0') {
+    errno = EINVAL;
+    return -1;
+  }
+  if (errno == ERANGE)
+    return -1;
+
+  const long sum = left_operand + right_operand;
+  if (sum < INT_MIN || sum > INT_MAX) {
+    errno = ERANGE;
+    return -1;
+  }
+
+  *out = (int)sum;
+  return 0;
+}
+
+int extract_query_value_dup(const char *query_string, char **out) {
+  if (!query_string || !out) {
+    errno = EINVAL;
+    return -1;
+  }
+  const char *expected_prefix = "query=";
+  const size_t prefix_length = strlen(expected_prefix);
+
+  if (strncmp(query_string, expected_prefix, prefix_length) != 0) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  const char *query_value = query_string + prefix_length;
+  const size_t query_value_length = strlen(query_value);
+
+  char *buffer = malloc(query_value_length + 1);
+  if (!buffer) {
+    errno = ENOMEM;
+    return -1;
+  }
+
+  memcpy(buffer, query_value, query_value_length + 1);
+  *out = buffer;
+  return 0;
+}

--- a/src/calc.h
+++ b/src/calc.h
@@ -1,0 +1,30 @@
+#ifndef CALC_H
+#define CALC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief 式を評価して加算結果を返す (例: "1+2" -> 3)
+ *
+ * @param expression 評価する式（例: "1+2"）
+ * @param out 計算結果の出力先
+ * @return 0 on success, -1 on error (errno set)
+ */
+int eval_sum(const char *expression, int *out);
+
+/**
+ * @brief クエリ文字列から "query=" パラメータの値を抽出する
+ *
+ * @param query_string クエリ文字列（例: "query=1+2"）
+ * @param out 抽出された値を格納するバッファへのポインタ（呼び出し側で解放が必要）
+ * @return 0 on success, -1 on error (errno set)
+ */
+int extract_query_value_dup(const char *query_string, char **out);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* CALC_H */

--- a/src/http_calc.c
+++ b/src/http_calc.c
@@ -1,0 +1,61 @@
+#include "http_calc.h"
+#include "calc.h"
+#include "http_request.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int validate_request_line(const RequestLine *request_line) {
+  if (!request_line) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (strcmp(request_line->path, "/calc") != 0) {
+    errno = EINVAL;
+    return -1;
+  }
+  return 0;
+}
+
+int calc_eval_request_line_dup(const RequestLine *request_line, char **out) {
+  if (!request_line || !out) {
+    errno = EINVAL;
+    return -1;
+  }
+  *out = NULL;
+
+  if (validate_request_line(request_line) == -1) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  char *query_value = NULL;
+  if (extract_query_value_dup(request_line->query, &query_value) == -1)
+    return -1;
+
+  int ans = 0;
+  const int status = eval_sum(query_value, &ans);
+  free(query_value);
+  if (status == -1)
+    return -1;
+
+  int need = snprintf(NULL, 0, "%d", ans);
+  if (need < 0)
+    return -1;
+
+  char *buf = malloc((size_t)need + 1);
+  if (!buf) {
+    errno = ENOMEM;
+    return -1;
+  }
+
+  if (snprintf(buf, (size_t)need + 1, "%d", ans) < 0) {
+    free(buf);
+    return -1;
+  }
+
+  *out = buf;
+  return 0;
+}

--- a/src/http_calc.h
+++ b/src/http_calc.h
@@ -1,0 +1,26 @@
+#ifndef HTTP_CALC_H
+#define HTTP_CALC_H
+
+#include "http_request.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief RequestLine を検証し、/calc?query=A+Bを評価して計算した文字列を返す。
+ *
+ * 成功時は 0 を返し、*out にNUL 終端文字列を格納する。 失敗時は -1
+ * を返し、errno に理由を設定する。
+ *
+ * @param request_line  入力の RequestLine へのポインタ
+ * @param out           出力文字列へのポインタ（成功時に mallocした文字列が入る）
+ * @return 0 on success, -1 on error (errno set)
+ */
+int calc_eval_request_line_dup(const RequestLine *request_line, char **out);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* HTTP_CALC_H */

--- a/src/http_client.c
+++ b/src/http_client.c
@@ -1,0 +1,61 @@
+#include "http_client.h"
+
+#include <errno.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <stdint.h>
+
+int open_client_fd(const char *host, const char *port) {
+  struct addrinfo hints, *addrinfo_list = NULL, *addr = NULL;
+  int socket_fd = -1;
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_protocol = 0;
+
+  int getaddrinfo_result = getaddrinfo(host, port, &hints, &addrinfo_list);
+  if (getaddrinfo_result != 0) {
+    return -1;
+  }
+
+  for (addr = addrinfo_list; addr != NULL;
+       addr = addr->ai_next) {
+    socket_fd = socket(addr->ai_family, addr->ai_socktype,
+                       addr->ai_protocol);
+    if (socket_fd < 0)
+      continue;
+    if (connect(socket_fd, addr->ai_addr, addr->ai_addrlen) ==
+        0)
+      break;
+    close(socket_fd);
+    socket_fd = -1;
+  }
+  freeaddrinfo(addrinfo_list);
+  return socket_fd;
+}
+
+int build_request_dup(char **out, size_t *out_len,
+                      const char *request_line) {
+  if (!request_line || !out || !out_len) { errno = EINVAL; return -1; }
+
+  const size_t line_len = strlen(request_line);
+  // +2 = "\r\n", +1 = NUL
+  if (line_len > SIZE_MAX - 3) { errno = EOVERFLOW; return -1; }
+
+  const size_t need = line_len + 2 + 1;
+  char *buf = (char *)malloc(need);
+  if (!buf) return -1;
+
+  int written_buffer_size = snprintf(buf, need, "%s\r\n", request_line);
+  if (written_buffer_size < 0 || (size_t)written_buffer_size >= need) { free(buf); errno = EOVERFLOW; return -1; }
+
+  *out = buf;
+  *out_len = (size_t)written_buffer_size;  // NULは含まない
+  return 0;
+}
+

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -1,0 +1,34 @@
+#ifndef HTTP_CLIENT_H
+#define HTTP_CLIENT_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ホストとポートに接続するクライアントソケットを開く
+ *
+ * @param host 接続先ホスト名またはIPアドレス
+ * @param port 接続先ポート番号（文字列）
+ * @return ソケットファイルディスクリプタ on success, -1 on error
+ */
+int open_client_fd(const char *host, const char *port);
+
+/**
+ * @brief HTTPリクエストを構築する
+ *
+ * @param out 出力バッファへのポインタ（必要に応じて realloc される）
+ * @param out_len 出力文字列の長さへのポインタ（NUL終端を含まない）
+ * @param request_line HTTPリクエストライン（例: "GET /path HTTP/1.1"）
+ * @return 0 on success, -1 on error (errno set)
+ */
+int build_request_dup(char **out, size_t *out_len,
+                      const char *request_line);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* HTTP_CLIENT_H */

--- a/src/http_request.c
+++ b/src/http_request.c
@@ -1,0 +1,138 @@
+#include "http_request.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+void request_line_cleanup(RequestLine *request_line) {
+  if (!request_line)
+    return;
+  free(request_line->path);
+  free(request_line->query);
+  request_line->path = NULL;
+  request_line->query = NULL;
+}
+
+int parse_request_line_dup(const char *line, RequestLine *out) {
+  if (!line || !out) {
+    errno = EINVAL;
+    return -1;
+  }
+  request_line_cleanup(out);
+
+  // method SP request-target SP HTTP-version
+  // ref: https://www.rfc-editor.org/rfc/rfc9112.html#name-request-line
+  const char *first_space = strchr(line, ' ');
+  if (!first_space) {
+    errno = EINVAL;
+    return -1;
+  }
+  const char *second_space = strchr(first_space + 1, ' ');
+  if (!second_space) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  // method
+  size_t method_len = (size_t)(first_space - line);
+  if (method_len == 0 || method_len >= METHOD_LEN) {
+    errno = ERANGE;
+    return -1;
+  }
+  memcpy(out->method, line, method_len);
+  out->method[method_len] = '\0';
+
+  // target
+  const char *target = first_space + 1;
+  size_t target_len = (size_t)(second_space - target);
+  if (target_len == 0) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  // path と query に分割
+  const char *question_mark = memchr(target, '?', target_len);
+  if (question_mark) {
+    size_t path_len = (size_t)(question_mark - target);
+    if (path_len == 0) {
+      errno = EINVAL;
+      return -1;
+    }
+
+    out->path = malloc(path_len + 1);
+    if (!out->path) {
+      errno = ENOMEM;
+      return -1;
+    }
+    memcpy(out->path, target, path_len);
+    out->path[path_len] = '\0';
+
+    size_t query_len = (size_t)(target_len - (path_len + 1));
+    if (query_len > 0) {
+      out->query = malloc(query_len + 1);
+      if (!out->query) {
+        free(out->path);
+        out->path = NULL;
+        errno = ENOMEM;
+        return -1;
+      }
+      memcpy(out->query, question_mark + 1, query_len);
+      out->query[query_len] = '\0';
+    } else {
+      out->query = malloc(1);
+      if (!out->query) {
+        free(out->path);
+        out->path = NULL;
+        errno = ENOMEM;
+        return -1;
+      }
+      out->query[0] = '\0';
+    }
+  } else {
+    out->path = malloc(target_len + 1);
+    if (!out->path) {
+      errno = ENOMEM;
+      return -1;
+    }
+    memcpy(out->path, target, target_len);
+    out->path[target_len] = '\0';
+
+    out->query = malloc(1);
+    if (!out->query) {
+      free(out->path);
+      out->path = NULL;
+      errno = ENOMEM;
+      return -1;
+    }
+    out->query[0] = '\0';
+  }
+
+  // version
+  const char *version = second_space + 1;
+  size_t version_len = strlen(version);
+  if (version_len == 0 || version_len >= VERSION_LEN) {
+    request_line_cleanup(out);
+    errno = ERANGE;
+    return -1;
+  }
+  memcpy(out->version, version, version_len);
+  out->version[version_len] = '\0';
+
+  return 0;
+}
+
+int validate_request_common(const RequestLine *request_line) {
+  if (!request_line) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (strcmp(request_line->method, "GET") != 0) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (strcmp(request_line->version, "HTTP/1.1") != 0) {
+    errno = EINVAL;
+    return -1;
+  }
+  return 0;
+}

--- a/src/http_request.h
+++ b/src/http_request.h
@@ -1,0 +1,49 @@
+#ifndef HTTP_REQUEST_H
+#define HTTP_REQUEST_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define METHOD_LEN  16
+#define VERSION_LEN 16
+
+typedef struct {
+    char method[METHOD_LEN];
+    char version[VERSION_LEN];
+    char *path;
+    char *query;
+} RequestLine;
+
+/**
+ * @brief HTTP/1.x のリクエストラインを構文解析して RequestLine 構造体に展開する。
+ *  例: "GET /calc?query=1+2 HTTP/1.1"
+ *
+ * @param line NUL 終端の入力文字列（CRLF は含まない）
+ * @param out  出力先（呼び出し側でallocate 済み）
+ * @return 0 on success, -1 on error (errno set)
+ */
+int parse_request_line_dup(const char *line, RequestLine *out);
+
+/**
+ * @brief HTTPメソッドとバージョンの整合性チェックを行う。
+ *
+ * @return 0 on success, -1 on error (errno = EINVAL)
+ */
+int validate_request_common(const RequestLine *request_line);
+
+/**
+ * @brief RequestLine構造体の動的に確保されたメモリ（path, query）を解放する。
+ * @param request_line クリーンアップするRequestLine構造体へのポインタ
+ */
+void request_line_cleanup(RequestLine *request_line);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* HTTP_REQUEST_H */
+
+

--- a/src/http_request_io.c
+++ b/src/http_request_io.c
@@ -1,0 +1,94 @@
+#include "http_request_io.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+static char *find_start_line_end(const char *buf, const size_t len) {
+  for (size_t i = 0; i + 1 < len; i++) {
+    if (buf[i] == '\r' && memcmp(buf + i, "\r\n", 2) == 0) {
+      return (char *)(buf + i);
+    }
+  }
+  return NULL;
+}
+
+#define INITIAL_CAPACITY 4096
+#define MAX_REQUEST_LINE_SIZE (1024 * 1024)
+
+int read_request_line(const int fd, char **out_line) {
+  if (!out_line)
+    return -1;
+  *out_line = NULL;
+
+  size_t buffer_capacity = INITIAL_CAPACITY;
+  size_t bytes_read = 0;
+  char *buffer = malloc(buffer_capacity);
+  if (!buffer)
+    return -1;
+
+  const char *line_end = NULL;
+  for (;;) {
+    if (bytes_read == buffer_capacity) {
+      if (buffer_capacity > SIZE_MAX / 2 ||
+          buffer_capacity * 2 > MAX_REQUEST_LINE_SIZE) {
+        free(buffer);
+        errno = ENOMEM;
+        return -1;
+      }
+      size_t new_capacity = buffer_capacity * 2;
+      char *temp_buffer = realloc(buffer, new_capacity);
+      if (!temp_buffer) {
+        free(buffer);
+        errno = ENOMEM;
+        return -1;
+      }
+      buffer = temp_buffer;
+      buffer_capacity = new_capacity;
+    }
+
+    ssize_t received_bytes =
+        recv(fd, buffer + bytes_read, buffer_capacity - bytes_read, 0);
+    if (received_bytes == 0) {
+      free(buffer);
+      errno = ECONNRESET;
+      return -1;
+    }
+    if (received_bytes < 0) {
+      int saved_errno = errno;
+      if (saved_errno == EINTR) {
+        continue;
+      }
+      free(buffer);
+      errno = saved_errno;
+      return -1;
+    }
+    bytes_read += (size_t)received_bytes;
+
+    line_end = find_start_line_end(buffer, bytes_read);
+    if (line_end)
+      break;
+  }
+
+  size_t line_length = (size_t)(line_end - buffer);
+  char *output = malloc(line_length + 1);
+  if (!output) {
+    free(buffer);
+    return -1;
+  }
+
+  size_t write_index = 0;
+  for (size_t read_index = 0; read_index < line_length; ++read_index) {
+    if (buffer[read_index] == '\r')
+      continue;
+    output[write_index++] = buffer[read_index];
+  }
+  output[write_index] = '\0';
+
+  free(buffer);
+  *out_line = output;
+  return 0;
+}

--- a/src/http_request_io.h
+++ b/src/http_request_io.h
@@ -1,0 +1,22 @@
+#ifndef HTTP_REQUEST_IO_H
+#define HTTP_REQUEST_IO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief FD から HTTP リクエストラインを読み取り、CRLF を除去した NUL 終端文字列を返す。
+ * 成功時 0、失敗時 -1（out は NULL のまま）。caller must free(*out_line)
+ *
+ * @param fd ソケットファイルディスクリプタ
+ * @param out_line 出力文字列へのポインタ（成功時に malloc した文字列が入る）
+ * @return 0 on success, -1 on error (errno set)
+ */
+int read_request_line(int fd, char **out_line);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* HTTP_REQUEST_IO_H */

--- a/src/http_response.c
+++ b/src/http_response.c
@@ -1,0 +1,37 @@
+#include "http_response.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define HTTP_RESPONSE_FORMAT                                                   \
+  "HTTP/1.1 200 OK\r\n"                                                        \
+  "Content-Length: %zu\r\n"                                                    \
+  "\r\n%s"
+
+int build_resp_dup(char **out, const char *body) {
+  if (!out || !body) {
+    errno = EINVAL;
+    return -1;
+  }
+  *out = NULL;
+
+  int required_size =
+      snprintf(NULL, 0, HTTP_RESPONSE_FORMAT, strlen(body), body);
+  if (required_size < 0)
+    return -1;
+
+  char *buffer = malloc((size_t)required_size + 1);
+  if (!buffer)
+    return -1;
+
+  int bytes_written = snprintf(buffer, (size_t)required_size + 1,
+                               HTTP_RESPONSE_FORMAT, strlen(body), body);
+  if (bytes_written < 0) {
+    free(buffer);
+    return -1;
+  }
+
+  *out = buffer;
+  return 0;
+}

--- a/src/http_response.h
+++ b/src/http_response.h
@@ -1,0 +1,23 @@
+#ifndef HTTP_RESPONSE_H
+#define HTTP_RESPONSE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief HTTPレスポンスを構築する
+ *
+ * 成功時は 0 を返し、*out にHTTP レスポンス文字列を格納する。 失敗時は -1を返す。
+ *
+ * @param out   出力文字列へのポインタ（成功時に malloc した文字列が入る）
+ * @param body  レスポンスボディの文字列
+ * @return 0 on success, -1 on error
+ */
+int build_resp_dup(char **out, const char *body);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* HTTP_RESPONSE_H */

--- a/src/socket_io.c
+++ b/src/socket_io.c
@@ -93,3 +93,21 @@ ssize_t read_all(int fd, char **buf) {
   (*buf)[total_bytes_read] = '\0';
   return (ssize_t)total_bytes_read;
 }
+
+int set_socket_timeout(const int fd, const int seconds) {
+  struct timeval timeout;
+  timeout.tv_sec = seconds;
+  timeout.tv_usec = 0;
+
+  if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO,
+                 &timeout, sizeof(timeout)) < 0) {
+    return -1;
+                 }
+
+  if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO,
+                 &timeout, sizeof(timeout)) < 0) {
+    return -1;
+                 }
+
+  return 0;
+}

--- a/src/socket_io.c
+++ b/src/socket_io.c
@@ -1,0 +1,95 @@
+#include "socket_io.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#define READ_INITIAL_CAPACITY 1024
+
+int send_all(int fd, const void *buf, size_t len) {
+  const char *position = (const char *)buf;
+  size_t bytes_remaining = len;
+  while (bytes_remaining > 0) {
+    ssize_t bytes_sent = send(fd, position, bytes_remaining, MSG_NOSIGNAL);
+    if (bytes_sent > 0) {
+      position += (size_t)bytes_sent;
+      bytes_remaining -= (size_t)bytes_sent;
+      continue;
+    }
+    if (bytes_sent == 0) {
+      errno = EPIPE;
+      return -1;
+    }
+    if (errno == EPIPE || errno == ECONNRESET)
+      return -1;
+    if (errno == EINTR)
+      continue;
+    return -1;
+  }
+  return 0;
+}
+
+int write_all(int fd, const void *buf, size_t len) {
+  const char *position = (const char *)buf;
+  size_t bytes_remaining = len;
+  while (bytes_remaining > 0) {
+    ssize_t bytes_written = write(fd, position, bytes_remaining);
+    if (bytes_written < 0) {
+      if (errno == EINTR)
+        continue;
+      return -1;
+    }
+    position += (size_t)bytes_written;
+    bytes_remaining -= (size_t)bytes_written;
+  }
+  return 0;
+}
+
+static size_t grow_capacity(size_t capacity) {
+  if (capacity > SIZE_MAX / 2) return SIZE_MAX;
+  return capacity * 2;
+}
+
+ssize_t read_all(int fd, char **buf) {
+  size_t capacity = READ_INITIAL_CAPACITY;
+  if (*buf == NULL) {
+    char *temp_buffer = (char *)malloc(capacity);
+    if (!temp_buffer)
+      return -1;
+    *buf = temp_buffer;
+  }
+
+  size_t total_bytes_read = 0;
+  for (;;) {
+    if (total_bytes_read == capacity) {
+      const size_t new_capacity = grow_capacity(capacity);
+      char *temp_buffer = (char *)realloc(*buf, new_capacity);
+      if (!temp_buffer)
+        return -1;
+      *buf = temp_buffer;
+      capacity= new_capacity;
+    }
+    const ssize_t bytes_read = read(fd, *buf + total_bytes_read, capacity - total_bytes_read);
+    if (bytes_read < 0) {
+      if (errno == EINTR)
+        continue;
+      return -1;
+    }
+    if (bytes_read == 0)
+      break; // EOF
+    total_bytes_read += (size_t)bytes_read;
+  }
+
+  // NUL 終端 1byte を確保
+  if (total_bytes_read == capacity) {
+    char *temp_buffer = (char *)realloc(*buf, capacity + 1);
+    if (!temp_buffer)
+      return -1;
+    *buf = temp_buffer;
+    capacity += 1;
+  }
+  (*buf)[total_bytes_read] = '\0';
+  return (ssize_t)total_bytes_read;
+}

--- a/src/socket_io.h
+++ b/src/socket_io.h
@@ -38,6 +38,15 @@ int write_all(int fd, const void *buf, size_t len);
  */
 ssize_t read_all(int fd, char **buf);
 
+/**
+ * @brief socketにタイムアウトを設定する
+ *
+ * @param fd ファイルディスクリプタ
+ * @param seconds タイムアウトの秒数
+ * @return 0 on success, -1 on error (errno set)
+ */
+int set_socket_timeout(int fd, int seconds);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/socket_io.h
+++ b/src/socket_io.h
@@ -1,0 +1,45 @@
+#ifndef SOCKET_IO_H
+#define SOCKET_IO_H
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief すべてのデータを送信する
+ *
+ * @param fd ソケットファイルディスクリプタ
+ * @param buf 送信するデータのポインタ
+ * @param len 送信するデータのサイズ
+ * @return 0 on success, -1 on error (errno set)
+ *         特殊なエラー: EPIPE/ECONNRESET の場合は errno が設定される
+ */
+int send_all(int fd, const void *buf, size_t len);
+
+/**
+ * @brief すべてのデータを書き込む
+ *
+ * @param fd ファイルディスクリプタ
+ * @param buf 書き込むデータのポインタ
+ * @param len 書き込むデータのサイズ
+ * @return 0 on success, -1 on error (errno set)
+ */
+int write_all(int fd, const void *buf, size_t len);
+
+/**
+ * @brief EOFまですべてのデータを読み取る
+ *
+ * @param fd ファイルディスクリプタ
+ * @param buf 読み取ったデータを格納するバッファへのポインタ
+ * @return 読み取ったバイト数 on success, -1 on error (errno set)
+ */
+ssize_t read_all(int fd, char **buf);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* SOCKET_IO_H */

--- a/tests/calc_test.cpp
+++ b/tests/calc_test.cpp
@@ -1,0 +1,74 @@
+#include "../src/calc.h"
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <cstring>
+
+TEST(CalcTest, EvalSumSimple) {
+  int result = 0;
+  ASSERT_EQ(0, eval_sum("1+2", &result));
+  EXPECT_EQ(3, result);
+}
+
+TEST(CalcTest, EvalSumNegativeNumbers) {
+  int result = 0;
+  ASSERT_EQ(0, eval_sum("-5+10", &result));
+  EXPECT_EQ(5, result);
+}
+
+TEST(CalcTest, EvalSumLargeNumbers) {
+  int result = 0;
+  ASSERT_EQ(0, eval_sum("1000000+2000000", &result));
+  EXPECT_EQ(3000000, result);
+}
+
+TEST(CalcTest, EvalSumInvalidExpression) {
+  int result = 0;
+  ASSERT_EQ(-1, eval_sum("invalid", &result));
+  EXPECT_EQ(EINVAL, errno);
+}
+
+TEST(CalcTest, EvalSumNullExpression) {
+  int result = 0;
+  ASSERT_EQ(-1, eval_sum(nullptr, &result));
+  EXPECT_EQ(EINVAL, errno);
+}
+
+TEST(CalcTest, EvalSumNullOutput) {
+  ASSERT_EQ(-1, eval_sum("1+2", nullptr));
+  EXPECT_EQ(EINVAL, errno);
+}
+
+TEST(CalcTest, ExtractQueryValueSimple) {
+  char *result = nullptr;
+  ASSERT_EQ(0, extract_query_value_dup("query=1+2", &result));
+  ASSERT_NE(nullptr, result);
+  EXPECT_STREQ("1+2", result);
+  free(result);
+}
+
+TEST(CalcTest, ExtractQueryValueComplex) {
+  char *result = nullptr;
+  ASSERT_EQ(0, extract_query_value_dup("query=100+200", &result));
+  ASSERT_NE(nullptr, result);
+  EXPECT_STREQ("100+200", result);
+  free(result);
+}
+
+TEST(CalcTest, ExtractQueryValueInvalidPrefix) {
+  char *result = nullptr;
+  ASSERT_EQ(-1, extract_query_value_dup("invalid=1+2", &result));
+  EXPECT_EQ(EINVAL, errno);
+}
+
+TEST(CalcTest, ExtractQueryValueNullInput) {
+  char *result = nullptr;
+  ASSERT_EQ(-1, extract_query_value_dup(nullptr, &result));
+  EXPECT_EQ(EINVAL, errno);
+}
+
+TEST(CalcTest, ExtractQueryValueNullOutput) {
+  ASSERT_EQ(-1, extract_query_value_dup("query=1+2", nullptr));
+  EXPECT_EQ(EINVAL, errno);
+}

--- a/tests/http_calc_test.cpp
+++ b/tests/http_calc_test.cpp
@@ -1,0 +1,58 @@
+#include <errno.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "http_calc.h"
+#include "http_request.h"
+
+static void expect_ok_str(const char *req, const char *expected) {
+  RequestLine request_line = {0};
+  errno = 0;
+  ASSERT_EQ(parse_request_line_dup(req, &request_line), 0) << strerror(errno);
+
+  char *out = nullptr;
+  errno = 0;
+  ASSERT_EQ(calc_eval_request_line_dup(&request_line, &out), 0)
+      << strerror(errno);
+  ASSERT_NE(out, nullptr);
+  EXPECT_STREQ(out, expected);
+  free(out);
+  request_line_cleanup(&request_line);
+}
+
+static void expect_err(const char *req, int expect_errno) {
+  RequestLine request_line = {0};
+  errno = 0;
+  if (parse_request_line_dup(req, &request_line) == -1) {
+    EXPECT_EQ(errno, expect_errno);
+    return;
+  }
+
+  char *out = nullptr;
+  errno = 0;
+  EXPECT_EQ(calc_eval_request_line_dup(&request_line, &out), -1);
+  EXPECT_EQ(errno, expect_errno);
+  EXPECT_EQ(out, nullptr);
+  request_line_cleanup(&request_line);
+}
+
+TEST(Calc, HappyPath) {
+  expect_ok_str("GET /calc?query=2+10 HTTP/1.1", "12");
+  expect_ok_str("GET /calc?query=-1+2 HTTP/1.1", "1");
+  expect_ok_str("GET /calc?query=0+0 HTTP/1.1", "0");
+}
+
+TEST(Calc, BadFormat) {
+  expect_err("", EINVAL);
+  expect_err("GET /bad?query=2+3 HTTP/1.1", EINVAL);
+  expect_err("GET /calc?foo=2+3 HTTP/1.1", EINVAL);
+  expect_err("GET /calc?query=2-3 HTTP/1.1", EINVAL);
+  expect_err("GET /calc?query=+3 HTTP/1.1", EINVAL);
+  expect_err("GET /calc?query=2+ HTTP/1.1", EINVAL);
+}
+
+TEST(Calc, Overflow) {
+  expect_err("GET /calc?query=2147483647+1 HTTP/1.1", ERANGE);
+  expect_err("GET /calc?query=-2147483648+-1 HTTP/1.1", ERANGE);
+}

--- a/tests/http_client_test.cpp
+++ b/tests/http_client_test.cpp
@@ -1,0 +1,54 @@
+#include "../src/http_client.h"
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+TEST(HttpClientTest, BuildRequestDupSimple) {
+  char *buf = nullptr;
+  size_t len = 0;
+
+  int result = build_request_dup(&buf, &len, "GET /path HTTP/1.1");
+  ASSERT_EQ(0, result);
+  ASSERT_NE(nullptr, buf);
+  EXPECT_GT(len, 0);
+
+  std::string expected = "GET /path HTTP/1.1\r\n";
+  EXPECT_STREQ(expected.c_str(), buf);
+  EXPECT_EQ(expected.length(), len);
+
+  free(buf);
+}
+
+TEST(HttpClientTest, BuildRequestDupWithQuery) {
+  char *buf = nullptr;
+  size_t len = 0;
+
+  int result = build_request_dup(&buf, &len, "GET /calc?query=1+2 HTTP/1.1");
+  ASSERT_EQ(0, result);
+  ASSERT_NE(nullptr, buf);
+
+  std::string expected = "GET /calc?query=1+2 HTTP/1.1\r\n";
+  EXPECT_STREQ(expected.c_str(), buf);
+
+  free(buf);
+}
+
+TEST(HttpClientTest, BuildRequestDupNullOut) {
+  size_t len = 0;
+
+  int result = build_request_dup(nullptr, &len, "GET / HTTP/1.1");
+  ASSERT_EQ(-1, result);
+  EXPECT_EQ(EINVAL, errno);
+}
+
+TEST(HttpClientTest, BuildRequestDupNullReqline) {
+  char *buf = nullptr;
+  size_t len = 0;
+
+  int result = build_request_dup(&buf, &len, nullptr);
+  ASSERT_EQ(-1, result);
+  EXPECT_EQ(EINVAL, errno);
+}

--- a/tests/http_request_test.cpp
+++ b/tests/http_request_test.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "http_request.h"
+#include "http_request_io.h"
+
+TEST(HttpRequestValidate, Happy) {
+    RequestLine request_line = {0};
+    ASSERT_EQ(parse_request_line_dup("GET /calc?query=1+2 HTTP/1.1", &request_line), 0) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(validate_request_common(&request_line), 0) << strerror(errno);
+    request_line_cleanup(&request_line);
+}
+
+TEST(HttpRequestValidate, RejectMethod) {
+    RequestLine request_line = {0};
+    ASSERT_EQ(parse_request_line_dup("POST /calc?query=1+2 HTTP/1.1", &request_line), 0) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(validate_request_common(&request_line), -1);
+    EXPECT_EQ(errno, EINVAL);
+    request_line_cleanup(&request_line);
+}
+
+TEST(HttpRequestValidate, RejectVersion) {
+    RequestLine request_line = {0};
+    ASSERT_EQ(parse_request_line_dup("GET /calc?query=1+2 HTTP/2", &request_line), 0) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(validate_request_common(&request_line), -1);
+    EXPECT_EQ(errno, EINVAL);
+    request_line_cleanup(&request_line);
+}
+
+static int make_socketpair(int fds[2]) {
+    return socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+}
+
+TEST(HttpRequestReadLine, ReadSingleChunk) {
+    int fds[2];
+    ASSERT_EQ(make_socketpair(fds), 0) << strerror(errno);
+
+    const char *line = "GET /calc?query=1+2 HTTP/1.1\r\n";
+    ssize_t wn = write(fds[0], line, strlen(line));
+    ASSERT_EQ(wn, (ssize_t)strlen(line));
+
+    char *out = nullptr;
+    errno = 0;
+    ASSERT_EQ(read_request_line(fds[1], &out), 0) << strerror(errno);
+    ASSERT_NE(out, nullptr);
+    EXPECT_STREQ(out, "GET /calc?query=1+2 HTTP/1.1");
+    free(out);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(HttpRequestReadLine, ReadInMultipleChunks) {
+    int fds[2];
+    ASSERT_EQ(make_socketpair(fds), 0) << strerror(errno);
+
+    const char *part1 = "GET /calc?query=1";
+    const char *part2 = "+2 HTTP/1.1\r\n";
+    ASSERT_EQ(write(fds[0], part1, strlen(part1)), (ssize_t)strlen(part1));
+    ASSERT_EQ(write(fds[0], part2, strlen(part2)), (ssize_t)strlen(part2));
+
+    char *out = nullptr;
+    errno = 0;
+    ASSERT_EQ(read_request_line(fds[1], &out), 0) << strerror(errno);
+    ASSERT_NE(out, nullptr);
+    EXPECT_STREQ(out, "GET /calc?query=1+2 HTTP/1.1");
+    free(out);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(HttpRequestReadLine, PeerClosedBeforeCRLF) {
+    int fds[2];
+    ASSERT_EQ(make_socketpair(fds), 0) << strerror(errno);
+
+    const char *partial = "GET /calc"; // CRLF なしで閉じる
+    ASSERT_EQ(write(fds[0], partial, strlen(partial)), (ssize_t)strlen(partial));
+    close(fds[0]);
+
+    char *out = nullptr;
+    errno = 0;
+    EXPECT_EQ(read_request_line(fds[1], &out), -1);
+    EXPECT_EQ(out, nullptr);
+
+    close(fds[1]);
+}
+
+

--- a/tests/http_response_test.cpp
+++ b/tests/http_response_test.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "http_response.h"
+
+TEST(HttpServer, BuildRespDupEmptyBody) {
+    char* out = nullptr;
+
+    EXPECT_EQ(build_resp_dup(&out, ""), 0);
+    ASSERT_NE(out, nullptr);
+
+    EXPECT_NE(strstr(out, "HTTP/1.1 200 OK"), nullptr);
+    EXPECT_NE(strstr(out, "Content-Length: 0"), nullptr);
+    EXPECT_NE(strstr(out, "\r\n\r\n"), nullptr);
+    
+    free(out);
+}
+
+TEST(HttpServer, BuildRespDupWithNumbers) {
+    char* out = nullptr;
+
+    EXPECT_EQ(build_resp_dup(&out, "123"), 0);
+    ASSERT_NE(out, nullptr);
+
+    EXPECT_NE(strstr(out, "HTTP/1.1 200 OK"), nullptr);
+    EXPECT_NE(strstr(out, "Content-Length: 3"), nullptr);
+    EXPECT_NE(strstr(out, "\r\n\r\n123"), nullptr);
+
+    free(out);
+}


### PR DESCRIPTION
## やったこと
オプショナルな機能のうち以下の対応を行いました

- [x] IPv4+v6両対応
- [x] signalを受け取ったら全コネクションが正常終了するようにする
- [x] 通信タイムアウトの設定

## IPv4/IPv6 の対応
`IPV6_V6ONLY`のフラグを0にすることで一つのポートでIPv4とIPv6のバケットを受け取れるようにしています。
ref: https://linuxjm.sourceforge.io/html/LDP_man-pages/man7/ipv6.7.html

この方法の他には、それぞれ専用のソケットを作成して対応する方法も考えられます。

```
$ netstat -an -p tcp -f inet6 | grep '*.80'
tcp46      0      0  *.80                   *.*                    LISTEN
```

```
$ curl -si -6 "http://localhost/calc?query=5+33"
HTTP/1.1 200 OK
Content-Length: 2

38% 
```
